### PR TITLE
Adding extra flags to run instructions

### DIFF
--- a/README
+++ b/README
@@ -9,5 +9,4 @@
         
 * Docker
     1. Чтобы собрать докер образ: `docker build -t repo_name/image_name:image_tag .`
-    2. Чтобы его запустить: `docker run -p 5000:5000 -v "$PWD/FlaskExample/data:/root/FlaskExample/data" repo_name/image_name`
-
+    2. Чтобы его запустить: `docker run -p 5000:5000 -v "$PWD/FlaskExample/data:/root/FlaskExample/data" --rm -i repo_name/image_name`


### PR DESCRIPTION
Docker documentation (https://docs.docker.com/v17.09/engine/reference/commandline/run/#options):
`--rm` Automatically remove the container when it exits
`-i` Keep STDIN open even if not attached

This gives an ability to stop server by Ctrl + C

Instead of `-i` you can use `-a` to attach STDIN, STDOUT and STDERR